### PR TITLE
Add ruleset JSON files and accompanying README file

### DIFF
--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -1,0 +1,49 @@
+# Rulesets for opensafely-actions repositories
+
+This directory houses two JSON files that can be used to import rulesets into
+a repository in the `opensafely-actions` organization.
+It is recommended to apply these rulesets to repositories housing reusable actions
+within the organization.
+
+### Importing a ruleset into a repository
+A ruleset can be imported into a repository by following these steps:
+ - Download the appropriate JSON file from this directory
+ - In the repo, head to ⚙️Settings > Rules > Rulesets
+ - Select New Ruleset > Import a ruleset
+ - Browse to the downloaded JSON file and select it
+ - Review the imported ruleset, adding further configuration (e.g. status checks) if needed
+ - Save your changes!
+
+Here is a video example,courtesy of
+[github's ruleset-recipes repository README](https://github.com/github/ruleset-recipes/blob/main/README.md).
+
+![Gif walking through the steps outline above to import a ruleset from a JSON file.](https://github.com/github/release-assets/assets/7575792/8806fa8c-b874-4a4e-97ef-4f8c238f4d29)
+
+
+### Rulesets
+
+#### Protect default branch (`protect-default-branch.json`)
+This ruleset applies to the default branch of a repository, and offers the following protections:
+- Prevent deletion by users
+- Require a PR before merging
+- Require status checks to pass before merging
+- Prevent force-pushing
+
+The above protections are in place to facilitate effective collaboration and minimise the risk of
+broken code being merged into the default branch.
+By ensuring that users work on separate branches prior to merging, users can work in parallel on
+features or bug fixes without affecting the default branch, and any conflicting code can be
+resolved in a PR before merging.
+
+When the ruleset is imported, the required status checks will have to be added manually in the web UI.
+Please ensure that this is done. If no status checks are added, an error will be raised by GitHub when
+attempting to save the ruleset.
+
+#### Protect semantically versioned tags (`protect-semantically-versioned-tags.json`)
+This ruleset applies to tags that follow the semantic versioning format (e.g. `v1.0.0`),
+and offers the following protections:
+- Prevent deletion by users
+- Prevent force-pushing
+
+Since semantically versioned tags are used to represent releases, the above protections are in place to
+ensure that the release history is preserved and that tags are not accidentally deleted or modified.

--- a/rulesets/protect-default-branch.json
+++ b/rulesets/protect-default-branch.json
@@ -1,0 +1,46 @@
+{
+    "name": "Protect default branch",
+    "target": "branch",
+    "source_type": "Repository",
+    "enforcement": "active",
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "~DEFAULT_BRANCH"
+            ]
+        }
+    },
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 0,
+                "dismiss_stale_reviews_on_push": false,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_review_thread_resolution": false,
+                "allowed_merge_methods": [
+                    "merge",
+                    "squash",
+                    "rebase"
+                ]
+            }
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": true,
+                "do_not_enforce_on_create": false,
+                "required_status_checks": []
+            }
+        }
+    ],
+    "bypass_actors": []
+}

--- a/rulesets/protect-semantically-versioned-tags.json
+++ b/rulesets/protect-semantically-versioned-tags.json
@@ -1,0 +1,23 @@
+{
+  "name": "Protect semantic version tags",
+  "target": "tag",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/tags/v*.*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
Related issue: #9 

- We would like to use rulesets to better protect the default branch and semantically versioned tags of reusable action repos.
- Add two JSON files which can be imported into GitHub's UI to create the desired rulesets.
- Also add a readme file to contain detailed instructions on how to use the files (incl. a reminder to manually add required status checks to the ruleset that protects the default branch).


The next step to complete the issue (apart from creating a push ruleset, [which is not something we are able to do at the moment](https://github.com/opensafely-actions/.github/issues/9#issuecomment-2741182773)) is to use the JSON files to create rulesets in all OpenSAFELY-owned repositories in the `opensafely-actions` org.

Particularly, I'd like to request feedback on whether the rule to prevent force-pushing to a semver tag is worth keeping, as this was not mentioned in the original issue, but might be a good rule to enforce anyway.