### PR TITLE
Add ruleset JSON files and accompanying README file

### DIFF
--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -1,0 +1,28 @@
+# Rulesets for opensafely-actions repositories
+
+
+This directory contains several [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets)
+for repositories in the opensafely-actions organisation.
+
+## Importing a ruleset into a repository
+Follow [the instructions in the GitHub docs for importing a ruleset](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/managing-rulesets-for-a-repository#importing-a-ruleset).
+
+Note that the Protect default branch ruleset requires status
+checks to pass before a topic branch can be merged into the default branch.
+**You will need to specify the applicable status checks manually in the web UI when you import the ruleset.**
+
+## Rulesets
+
+Refer to the [GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets) if you need help interpreting specific rules.
+
+### Protect default branch
+This ruleset protects the default branch of a repository.
+The protections are in place to facilitate effective collaboration and minimise the risk of broken code being merged into the default branch.
+Via the ruleset, we encourage that users work on separate branches prior to merging,
+which allows users to work in parallel on features or bug fixes without affecting the default branch,
+and to resolve any conflicting code in a pull request before merging.
+
+### Protect semantically versioned tags
+This ruleset protects tags that follow the semantic versioning format (e.g. `v1.0.0`).
+Since semantically versioned tags are used to represent releases,
+the protections are in place to ensure that the release history is preserved and that tags are not accidentally deleted or modified.

--- a/rulesets/protect-default-branch.json
+++ b/rulesets/protect-default-branch.json
@@ -1,0 +1,46 @@
+{
+    "name": "Protect default branch",
+    "target": "branch",
+    "source_type": "Repository",
+    "enforcement": "active",
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "~DEFAULT_BRANCH"
+            ]
+        }
+    },
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 0,
+                "dismiss_stale_reviews_on_push": false,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_review_thread_resolution": false,
+                "allowed_merge_methods": [
+                    "merge",
+                    "squash",
+                    "rebase"
+                ]
+            }
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": true,
+                "do_not_enforce_on_create": false,
+                "required_status_checks": []
+            }
+        }
+    ],
+    "bypass_actors": []
+}

--- a/rulesets/protect-semantically-versioned-tags.json
+++ b/rulesets/protect-semantically-versioned-tags.json
@@ -1,0 +1,23 @@
+{
+  "name": "Protect semantic version tags",
+  "target": "tag",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/tags/v*.*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
Related issue: #9. 
Previous iteration of this PR: #10, the comments on which have been addressed here. [New changes are shown here](https://github.com/opensafely-actions/.github/compare/dfde365f54c93bb635f9245d1f8fd6cf3f8ac799..d1459be97c5ea74e504d953815ee6787ad373797).

See the issue for context, and the commit message for implementation details.

The rulesets have been tested by trying to violate them on a separate user-owned public repo.
In each case of attempted rule violation (e.g., upon trying to delete the default branch), the attempt has been blocked in some way. Screenshots or copy-pasted terminal output of the blocked attempts are in the [issue comment](https://github.com/opensafely-actions/.github/issues/9#issuecomment-2741182773).

Note that the original issue comment wanted to create a rule to prevent users from pushing commits that include changes to files in the .github directory. This is not possible without a push ruleset, but push rulesets are not available for public repos. Since all our reusable action repos are public repos, it is not possible to implement such a rule. This has been noted in the issue. 

### Next steps
Merging this PR does not complete the issue, as the issue also requires the rulesets to be applied to all the OpenSAFELY-owned repositories in the opensafely-actions org. 
After this PR is merged, we should import the rulesets into the relevant repos to close the issue.

### Additional notes
Particularly, I'd like to request feedback on whether the rule to prevent force-pushing to a semver tag is worth keeping, as this was not mentioned in the original issue, but might be a good rule to enforce anyway:
https://github.com/opensafely-actions/.github/blob/27126de7b5eeb7f749f6df8990d4ee193f9340fa/rulesets/protect-semantically-versioned-tags.json#L18-L20